### PR TITLE
feat: Add Docker Compose setup for client and server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Git
+.git
+.gitignore
+
+# Node modules
+node_modules
+
+# Build artifacts (client-side)
+dist
+build
+output
+
+# VSCode specific
+.vscode
+
+# Operating System specific
+.DS_Store
+Thumbs.db
+
+# Docker specific (avoid including these if they are in the context)
+Dockerfile.client
+Dockerfile.server
+docker-compose.yml
+
+# Log files (if any are generated locally)
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local environment variables / config (if any)
+.env
+.env.local
+.env.*.local

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,42 @@
+# Stage 1: Build the React application
+FROM node:20-alpine AS builder
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Copy package.json, package-lock.json, and rsbuild.config.js
+COPY package.json package-lock.json ./
+COPY rsbuild.config.js ./
+
+# Copy the public and src directories
+COPY public/ ./public/
+COPY src/ ./src/
+
+# Install dependencies
+RUN npm install --legacy-peer-deps
+
+# Build the application
+RUN npm run build
+
+# Stage 2: Serve the static files from the build
+FROM node:20-alpine
+
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to install 'serve'
+COPY package.json package-lock.json ./
+
+# Install only 'serve' and production dependencies (though serve is the main one here for this stage)
+# We run a full npm install to ensure 'serve' is available via npx or in node_modules/.bin
+RUN npm install --production --legacy-peer-deps
+
+# Copy the build output from the builder stage
+COPY --from=builder /usr/src/app/dist ./dist
+
+# Expose port 3000 (or whatever port `serve` will use)
+EXPOSE 3000
+
+# Command to serve the app
+# The -s flag indicates that it's a single-page application
+# The -l flag specifies the listener port
+CMD ["npx", "serve", "-s", "./dist", "-l", "3000"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,24 @@
+# Use an official Node.js runtime as a parent image
+FROM node:20-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (or npm-shrinkwrap.json)
+COPY package.json package-lock.json ./
+
+# Install production dependencies
+RUN npm install --production --legacy-peer-deps
+
+# Copy the rest of the application code
+COPY server.js .
+COPY myyahoo.json .
+
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
+
+# Define environment variable (if needed, though server.js doesn't seem to require one for host/port)
+# ENV NODE_ENV production
+
+# Run the app when the container launches
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,51 @@ To start the server portion of this app run:
  
 
  I believe there are a few other sports available.  
+
+## Running with Docker Compose
+
+This application can be built and run using Docker Compose. This setup includes both the client and server services.
+
+**Prerequisites:**
+*   Docker installed and running on your system.
+*   Docker Compose installed (usually comes with Docker Desktop).
+
+**Steps:**
+
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+
+2.  **Build and run the application:**
+    Open a terminal in the project's root directory (where `docker-compose.yml` is located) and run:
+    ```bash
+    docker-compose up --build -d
+    ```
+    *   `--build`: Forces Docker Compose to build the images before starting the containers.
+    *   `-d`: Runs the containers in detached mode (in the background).
+
+3.  **Accessing the application:**
+    *   The client (frontend) will be available at [http://localhost:3000](http://localhost:3000).
+    *   The server API will be available at [http://localhost:5000](http://localhost:5000) (though you'll typically interact with it through the client).
+
+4.  **Stopping the application:**
+    To stop the running containers, execute:
+    ```bash
+    docker-compose down
+    ```
+
+5.  **Viewing logs:**
+    To view the logs from the running containers:
+    ```bash
+    docker-compose logs -f
+    ```
+    Or for a specific service:
+    ```bash
+    docker-compose logs -f client
+    docker-compose logs -f server
+    ```
+
+**Configuration:**
+*   The server uses the `myyahoo.json` file for its configuration. This file is mounted directly from your project directory into the server container. Any changes you make to `myyahoo.json` locally will be reflected in the running server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./myyahoo.json:/usr/src/app/myyahoo.json
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+    ports:
+      - "3000:3000"
+    environment:
+      PUBLIC_API_URL: http://server:5000
+    depends_on:
+      - server
+    restart: unless-stopped
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",
     "rss-parser": "^3.13.0",
-    "yahoo-finance2": "^2.13.3"
+    "yahoo-finance2": "^2.13.3",
+    "serve": "^14.2.3"
   },
   "scripts": {
     "start": "rsbuild dev",

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,7 @@
 export const fetchData = async (endpoint, setState, timestampKey, prefix, setTimestamps) => {
   try {
-    const url = `http://localhost:5000${endpoint}`;
+    const apiUrl = process.env.PUBLIC_API_URL || 'http://localhost:5000';
+    const url = `${apiUrl}${endpoint}`;
     const response = await fetch(url, { method: 'POST' });
     const data = await response.json();
     setState(data);


### PR DESCRIPTION
This commit introduces a Docker Compose configuration to build and run both the client and server applications in isolated containers.

Key changes include:
- Added `Dockerfile.server` to containerize the Node.js backend server.
- Added `Dockerfile.client` for a multi-stage build of the React client, serving static assets with the `serve` package.
- Modified `src/api.js` to use the `PUBLIC_API_URL` environment variable for the backend URL, allowing dynamic configuration in Docker.
- Added `serve` to `package.json` dependencies for serving client static files.
- Created `docker-compose.yml` to define and orchestrate the `client` and `server` services, including network configuration and volume mounting for `myyahoo.json`.
- Added a `.dockerignore` file to optimize Docker build contexts.
- Updated `README.md` with instructions on how to use Docker Compose to run the application.