### PR TITLE
feat: Change client default port from 3000 to 3399

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -33,10 +33,10 @@ RUN npm install --production --legacy-peer-deps
 # Copy the build output from the builder stage
 COPY --from=builder /usr/src/app/dist ./dist
 
-# Expose port 3000 (or whatever port `serve` will use)
-EXPOSE 3000
+# Expose port 3399 (or whatever port `serve` will use)
+EXPOSE 3399
 
 # Command to serve the app
 # The -s flag indicates that it's a single-page application
 # The -l flag specifies the listener port
-CMD ["npx", "serve", "-s", "./dist", "-l", "3000"]
+CMD ["npx", "serve", "-s", "./dist", "-l", "3399"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: .
       dockerfile: Dockerfile.client
     ports:
-      - "3000:3000"
+      - "3399:3399"
     environment:
       PUBLIC_API_URL: http://server:5000
     depends_on:

--- a/rsbuild.config.js
+++ b/rsbuild.config.js
@@ -7,5 +7,8 @@ export default defineConfig({
       index: './src/index.js',
     },
   },
+  server: {
+    port: 3399,
+  },
   plugins: [pluginReact()],
 });


### PR DESCRIPTION
This commit updates the default client-side port from 3000 to 3399.

The following files were modified:
- `docker-compose.yml`: Changed the client service port mapping from `3000:3000` to `3399:3399`.
- `rsbuild.config.js`: Configured the Rsbuild development server to use `server.port = 3399`.
- `Dockerfile.client`: Updated the `EXPOSE` instruction to `EXPOSE 3399` and modified the `CMD` to run `npx serve` on port 3399 (`-l 3399`).

These changes ensure that both the development environment (via `rsbuild dev`) and the production container (via `serve`) consistently use port 3399, and Docker maps this port correctly to the host.