### PR TITLE
Fix: Update page title to myYahooClone

### DIFF
--- a/rsbuild.config.js
+++ b/rsbuild.config.js
@@ -10,5 +10,10 @@ export default defineConfig({
   server: {
     port: 3399,
   },
+  tools: {
+    htmlPlugin: {
+      title: 'myYahooClone',
+    },
+  },
   plugins: [pluginReact()],
 });


### PR DESCRIPTION
The page title was previously displaying the RSbuild default ("RSbuild App"). This change updates the `rsbuild.config.js` to correctly set the desired page title "myYahooClone" using the `tools.htmlPlugin.title` configuration.