### PR TITLE
Migrate to feedsmith for RSS parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "bootstrap": "^5.3.5",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "feedsmith": "^2.9.1",
         "openmeteo": "^1.2.0",
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.0.0",
-        "rss-parser": "^3.13.0",
         "serve": "^14.2.3",
         "yahoo-finance2": "^3.11.2"
       },
@@ -1367,15 +1367,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
@@ -1617,6 +1608,62 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/feedsmith": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/feedsmith/-/feedsmith-2.9.1.tgz",
+      "integrity": "sha512-XsHf3lv+i3juaUjE4FHB56nKN+lwvjJTmH3ZMVO4yELaeHV/siLygDlmfJXJoMzP9JZC+zYZUhPEH+9tL3ijzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^7.0.1",
+        "fast-xml-parser": "~5.4.2"
+      }
+    },
+    "node_modules/feedsmith/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/fetch-mock-cache": {
       "version": "2.3.1",
@@ -2338,6 +2385,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
@@ -2655,16 +2717,6 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
     },
-    "node_modules/rss-parser": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
-      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^2.0.3",
-        "xml2js": "^0.5.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2690,12 +2742,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "license": "BlueOak-1.0.0"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -3058,6 +3104,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3351,28 +3409,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/yahoo-finance2": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "bootstrap": "^5.3.5",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "feedsmith": "^2.9.1",
     "openmeteo": "^1.2.0",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",
-    "rss-parser": "^3.13.0",
-    "yahoo-finance2": "^3.11.2",
-    "serve": "^14.2.3"
+    "serve": "^14.2.3",
+    "yahoo-finance2": "^3.11.2"
   },
   "scripts": {
     "start": "rsbuild dev",

--- a/server.js
+++ b/server.js
@@ -5,8 +5,7 @@ const bodyParser = require('body-parser');
 const fs = require("fs");
 const yahooFinance = require('yahoo-finance2').default;
 const fetchWeatherApi = require('openmeteo').fetchWeatherApi;
-const RSSParser = require('rss-parser');
-const rssParser = new RSSParser();
+const { parseFeed } = require('feedsmith');
 const axios = require("axios");
 
 const app = express();
@@ -137,6 +136,21 @@ async function getStockPrices(symbols)
     return Promise.all(promises);
 }
 
+// Function to strip HTML and provide plain text similar to contentSnippet
+const stripHtml = (html) => {
+    if (!html) return undefined;
+    // Remove HTML tags
+    let text = html.replace(/<[^>]*>?/gm, '');
+    // Basic HTML entity decoding
+    text = text.replace(/&nbsp;/g, ' ')
+               .replace(/&amp;/g, '&')
+               .replace(/&lt;/g, '<')
+               .replace(/&gt;/g, '>')
+               .replace(/&quot;/g, '"')
+               .replace(/&#39;/g, "'");
+    return text.trim();
+};
+
 async function getNewsFeedInfo(feedList)
 {
     // Detect if the feedList is in the old format
@@ -152,19 +166,42 @@ async function getNewsFeedInfo(feedList)
         for (let j = 0; j < category.feeds.length; j++) {
             let feed = category.feeds[j];
             try {
-                let feedData = await rssParser.parseURL(feed.url);
-                // Validate feedData to prevent bad data from corrupting feeds
-                if (!feedData || typeof feedData !== 'object' || !Array.isArray(feedData.items)) {
-                    throw new Error('Invalid RSS feed data');
+                let response = await axios.get(feed.url, {
+                    timeout: 10000,
+                    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36' }
+                });
+                let parsedResult = parseFeed(response.data);
+                if (!parsedResult || !parsedResult.feed) {
+                    throw new Error('Failed to parse feed data');
                 }
-                feedData.name = feed.name;
-                feedData.items = feedData.items.slice(0, 5); // Limit to 5 items
-                // Strip unnecessary properties from items, keeping only title, contentSnippet, and link
-                feedData.items = feedData.items.map(item => ({
-                    title: item.title,
-                    contentSnippet: item.contentSnippet,
-                    link: item.link
-                }));
+                let parsed = parsedResult.feed;
+                let items = parsed.items || parsed.entries || [];
+
+                // Validate items to prevent bad data from corrupting feeds
+                if (!Array.isArray(items)) {
+                    throw new Error('Invalid RSS feed items');
+                }
+
+                let feedData = {
+                    title: parsed.title,
+                    description: parsed.description,
+                    link: parsed.link,
+                    pubDate: parsed.pubDate,
+                    language: parsed.language,
+                    copyright: parsed.copyright,
+                    ttl: parsed.ttl,
+                    image: parsed.image,
+                    name: feed.name,
+                    items: items.slice(0, 5).map(item => {
+                        const content = item.description || item.summary || item.contentSnippet || item.content;
+                        return {
+                            title: item.title,
+                            contentSnippet: stripHtml(content),
+                            link: item.link
+                        };
+                    })
+                };
+
                 category.feeds[j].feedData = feedData;
             } catch (err) {
                 console.log(`Error pulling news feed: ${feed.url}, Error: ${err}`);


### PR DESCRIPTION
Replaced the deprecated rss-parser with feedsmith. ensured the data format and functionality remain unchanged by mapping the parsed feed and items to the original expected structure and implementing a plain-text contentSnippet field. verified with backend endpoint testing.

---
*PR created automatically by Jules for task [17048226975171190630](https://jules.google.com/task/17048226975171190630) started by @ccarlin*